### PR TITLE
chore: expand test coverage and simplify body-dump handling

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -1,7 +1,6 @@
 package echootelmiddleware
 
 import (
-	"fmt"
 	"strings"
 	"unicode/utf8"
 
@@ -152,9 +151,8 @@ func prepareAttrs(config OtelConfig, attrs ...attribute.KeyValue) []attribute.Ke
 func formatKey(k, prefix string) attribute.Key {
 	k = strings.ToLower(k)
 	k = strings.ReplaceAll(k, "-", "_")
-	k = fmt.Sprintf("%s.%s", prefix, k)
 
-	return attribute.Key(k)
+	return attribute.Key(prefix + "." + k)
 }
 
 func defaultBodySkipper(_ *echo.Context) (skipReqBody bool, skipRespBody bool) {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -125,6 +125,72 @@ func TestPrepareAttrs(t *testing.T) {
 	require.Equal(t, int64(3), attrs[1].Value.AsInt64())
 }
 
+func TestFormatKey(t *testing.T) {
+	t.Run("lowercase and replaces hyphens with underscores", func(t *testing.T) {
+		require.Equal(t, attribute.Key("http.request.headers.content_type"), formatKey("Content-Type", "http.request.headers"))
+	})
+
+	t.Run("no hyphens no change", func(t *testing.T) {
+		require.Equal(t, attribute.Key("http.request.headers.accept"), formatKey("Accept", "http.request.headers"))
+	})
+
+	t.Run("multiple hyphens", func(t *testing.T) {
+		require.Equal(t, attribute.Key("http.response.headers.x_request_id"), formatKey("X-Request-ID", "http.response.headers"))
+	})
+}
+
+func TestLimitStringEdgeCases(t *testing.T) {
+	t.Run("size zero returns original", func(t *testing.T) {
+		require.Equal(t, "abc", limitString("abc", 0))
+	})
+
+	t.Run("negative size returns original", func(t *testing.T) {
+		require.Equal(t, "abc", limitString("abc", -5))
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		require.Equal(t, "", limitString("", 10))
+	})
+
+	t.Run("empty string with zero size", func(t *testing.T) {
+		require.Equal(t, "", limitString("", 0))
+	})
+}
+
+func TestLimitStringWithDotsUTF8(t *testing.T) {
+	// "abcdefgh" + euro sign (3 bytes) + "ij". Total = 13 bytes.
+	// With size=11, size-3=8 truncates cleanly at "abcdefgh".
+	input := "abcdefgh" + string([]byte{0xe2, 0x82, 0xac}) + "ij"
+	require.Equal(t, "abcdefgh...", limitStringWithDots(input, 11))
+
+	// size=12, size-3=9 falls into middle of the 3-byte euro rune;
+	// limitString trims it off, yielding "abcdefgh" + "...".
+	require.Equal(t, "abcdefgh...", limitStringWithDots(input, 12))
+}
+
+func TestPrepareAttrsFastPath(t *testing.T) {
+	cfg := OtelConfig{} // no limits, no newline removal
+
+	in := []attribute.KeyValue{
+		attribute.String("keyName", "a\nbcdef"),
+		attribute.Int("intKey", 7),
+	}
+
+	out := prepareAttrs(cfg, in...)
+
+	require.Len(t, out, 2)
+	require.Equal(t, attribute.Key("keyName"), out[0].Key)
+	require.Equal(t, "a\nbcdef", out[0].Value.AsString())
+	require.Equal(t, attribute.Key("intKey"), out[1].Key)
+	require.Equal(t, int64(7), out[1].Value.AsInt64())
+}
+
+func TestDefaultBodySkipper(t *testing.T) {
+	skipReq, skipResp := defaultBodySkipper(nil)
+	require.False(t, skipReq)
+	require.False(t, skipResp)
+}
+
 func TestGetRequestID(t *testing.T) {
 	e := echo.New()
 

--- a/middleware.go
+++ b/middleware.go
@@ -74,6 +74,13 @@ func shouldSkipMiddleware(c *echo.Context, config OtelConfig) bool {
 	return config.Skipper(c) || c.Request() == nil || c.Response() == nil
 }
 
+// invokeErrorHandler invokes the Echo HTTPErrorHandler when available.
+func invokeErrorHandler(c *echo.Context, err error) {
+	if c.Echo() != nil {
+		c.Echo().HTTPErrorHandler(c, err)
+	}
+}
+
 // processNextHandler calls the next handler and processes any errors.
 func processNextHandler(c *echo.Context, next echo.HandlerFunc, config OtelConfig, span oteltrace.Span) error {
 	err := next(c)
@@ -83,9 +90,7 @@ func processNextHandler(c *echo.Context, next echo.HandlerFunc, config OtelConfi
 		setAttr(span, config, attribute.String("echo.error", err.Error()))
 
 		// Call custom registered error handler
-		if c.Echo() != nil {
-			c.Echo().HTTPErrorHandler(c, err)
-		}
+		invokeErrorHandler(c, err)
 	}
 
 	return err
@@ -112,10 +117,13 @@ func dumpRequestBody(request *http.Request, config OtelConfig, span oteltrace.Sp
 	reqBody := []byte("[excluded]")
 
 	if !skipReqBody {
-		var err error
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			span.RecordError(err)
 
-		reqBody, err = io.ReadAll(request.Body)
-		if err == nil {
+			reqBody = []byte("[read-error]")
+		} else {
+			reqBody = body
 			_ = request.Body.Close()
 			request.Body = io.NopCloser(bytes.NewBuffer(reqBody)) // reset original request body
 		}
@@ -180,7 +188,7 @@ func dumpResponseHeaders(c *echo.Context, config OtelConfig, span oteltrace.Span
 func dumpResponseBody(respDumper *response.Dumper, config OtelConfig, span oteltrace.Span, skipRespBody bool) {
 	respBody := respDumper.GetResponse()
 
-	if respBody != "" && skipRespBody {
+	if skipRespBody {
 		respBody = "[excluded]"
 	}
 
@@ -340,9 +348,7 @@ func MiddlewareWithConfig(config OtelConfig) echo.MiddlewareFunc {
 
 				err := next(c)
 				if err != nil {
-					if c.Echo() != nil {
-						c.Echo().HTTPErrorHandler(c, err)
-					}
+					invokeErrorHandler(c, err)
 				}
 
 				return err

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -562,6 +562,162 @@ func TestErrorNotSwallowedByMiddleware(t *testing.T) {
 	assert.Equal(t, assert.AnError, err)
 }
 
+func TestNilRequestBodyWithBodyDump(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+
+	router := echo.New()
+	router.Use(MiddlewareWithConfig(OtelConfig{TracerProvider: provider, IsBodyDump: true}))
+	router.GET(userEndpoint, func(c *echo.Context) error {
+		return c.String(http.StatusOK, userID)
+	})
+
+	r := httptest.NewRequest("GET", userURL, nil)
+	r.Body = nil // ensure nil body
+	w := httptest.NewRecorder()
+
+	require.NotPanics(t, func() {
+		router.ServeHTTP(w, r)
+	})
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	attrs := spans[0].Attributes()
+	// No http.request.body attribute should be set for a nil request body.
+	for _, attr := range attrs {
+		assert.NotEqual(t, attribute.Key("http.request.body"), attr.Key)
+	}
+}
+
+func TestEmptyResponseBodyExcluded(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+
+	router := echo.New()
+	router.Use(MiddlewareWithConfig(OtelConfig{
+		TracerProvider: provider,
+		IsBodyDump:     true,
+		BodySkipper: func(*echo.Context) (bool, bool) {
+			return false, true
+		},
+	}))
+	router.GET(userEndpoint, func(c *echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
+
+	r := httptest.NewRequest("GET", userURL, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	attrs := spans[0].Attributes()
+	assert.Contains(t, attrs, attribute.String("http.response.body", "[excluded]"))
+}
+
+func TestNonRecordingSpanBranch(t *testing.T) {
+	router := echo.New()
+	// noop tracer provider produces non-recording spans.
+	router.Use(MiddlewareWithConfig(OtelConfig{TracerProvider: noop.NewTracerProvider()}))
+
+	var handlerCalled bool
+
+	router.GET(userEndpoint, func(c *echo.Context) error {
+		handlerCalled = true
+		return c.String(http.StatusOK, userID)
+	})
+
+	r := httptest.NewRequest("GET", userURL, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	assert.True(t, handlerCalled)
+	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+}
+
+func TestNonRecordingSpanErrorPropagated(t *testing.T) {
+	router := echo.New()
+	router.Use(MiddlewareWithConfig(OtelConfig{TracerProvider: noop.NewTracerProvider()}))
+	router.GET("/err", func(c *echo.Context) error {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request")
+	})
+
+	r := httptest.NewRequest("GET", "/err", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+}
+
+func TestResponseStatusNoDumperNoError(t *testing.T) {
+	e := echo.New()
+	c := e.NewContext(httptest.NewRequest("GET", "/", nil), httptest.NewRecorder())
+	// Response has not been written; echo.UnwrapResponse should still succeed
+	// and return the current status (0 before any write).
+	status := responseStatus(c, nil, nil)
+	assert.Equal(t, 0, status)
+}
+
+func TestPathParameterAttribute(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+
+	router := echo.New()
+	router.Use(MiddlewareWithConfig(OtelConfig{TracerProvider: provider}))
+	router.GET(userEndpoint, func(c *echo.Context) error {
+		return c.String(http.StatusOK, c.Param("id"))
+	})
+
+	r := httptest.NewRequest("GET", userURL, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	attrs := spans[0].Attributes()
+	assert.Contains(t, attrs, attribute.String("http.path.id", userID))
+}
+
+// failingReader is an io.ReadCloser that always returns an error on Read.
+type failingReader struct{}
+
+func (failingReader) Read(_ []byte) (int, error) { return 0, errors.New("boom") }
+func (failingReader) Close() error               { return nil }
+
+func TestDumpRequestBodyReadError(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+
+	router := echo.New()
+	router.Use(MiddlewareWithConfig(OtelConfig{TracerProvider: provider, IsBodyDump: true}))
+	router.GET(userEndpoint, func(c *echo.Context) error {
+		return c.String(http.StatusOK, userID)
+	})
+
+	r := httptest.NewRequest("GET", userURL, nil)
+	r.Body = failingReader{}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+	span := spans[0]
+	attrs := span.Attributes()
+	assert.Contains(t, attrs, attribute.String("http.request.body", "[read-error]"))
+
+	// The read error should be recorded as a span event.
+	var found bool
+
+	for _, ev := range span.Events() {
+		if ev.Name == "exception" {
+			found = true
+			break
+		}
+	}
+
+	assert.True(t, found, "expected an exception event for the read error")
+}
+
 func BenchmarkWithMiddleware(b *testing.B) {
 	router := echo.New()
 	router.Use(Middleware())

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -572,7 +572,7 @@ func TestNilRequestBodyWithBodyDump(t *testing.T) {
 		return c.String(http.StatusOK, userID)
 	})
 
-	r := httptest.NewRequest("GET", userURL, nil)
+	r := httptest.NewRequest("GET", userURL, http.NoBody)
 	r.Body = nil // ensure nil body
 	w := httptest.NewRecorder()
 
@@ -605,7 +605,7 @@ func TestEmptyResponseBodyExcluded(t *testing.T) {
 		return c.NoContent(http.StatusOK)
 	})
 
-	r := httptest.NewRequest("GET", userURL, nil)
+	r := httptest.NewRequest("GET", userURL, http.NoBody)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -627,7 +627,7 @@ func TestNonRecordingSpanBranch(t *testing.T) {
 		return c.String(http.StatusOK, userID)
 	})
 
-	r := httptest.NewRequest("GET", userURL, nil)
+	r := httptest.NewRequest("GET", userURL, http.NoBody)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -638,11 +638,11 @@ func TestNonRecordingSpanBranch(t *testing.T) {
 func TestNonRecordingSpanErrorPropagated(t *testing.T) {
 	router := echo.New()
 	router.Use(MiddlewareWithConfig(OtelConfig{TracerProvider: noop.NewTracerProvider()}))
-	router.GET("/err", func(c *echo.Context) error {
+	router.GET("/err", func(_ *echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "bad request")
 	})
 
-	r := httptest.NewRequest("GET", "/err", nil)
+	r := httptest.NewRequest("GET", "/err", http.NoBody)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -651,7 +651,7 @@ func TestNonRecordingSpanErrorPropagated(t *testing.T) {
 
 func TestResponseStatusNoDumperNoError(t *testing.T) {
 	e := echo.New()
-	c := e.NewContext(httptest.NewRequest("GET", "/", nil), httptest.NewRecorder())
+	c := e.NewContext(httptest.NewRequest("GET", "/", http.NoBody), httptest.NewRecorder())
 	// Response has not been written; echo.UnwrapResponse should still succeed
 	// and return the current status (0 before any write).
 	status := responseStatus(c, nil, nil)

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -668,7 +668,7 @@ func TestPathParameterAttribute(t *testing.T) {
 		return c.String(http.StatusOK, c.Param("id"))
 	})
 
-	r := httptest.NewRequest("GET", userURL, nil)
+	r := httptest.NewRequest("GET", userURL, http.NoBody)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
@@ -694,7 +694,7 @@ func TestDumpRequestBodyReadError(t *testing.T) {
 		return c.String(http.StatusOK, userID)
 	})
 
-	r := httptest.NewRequest("GET", userURL, nil)
+	r := httptest.NewRequest("GET", userURL, http.NoBody)
 	r.Body = failingReader{}
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)


### PR DESCRIPTION
## Summary

- Expand unit test coverage for helpers (`formatKey`, `limitString` edge cases, `limitStringWithDots` UTF-8 boundary, `prepareAttrs` fast path, `defaultBodySkipper`) and middleware (nil request body with `IsBodyDump`, excluded empty response body, non-recording/noop span branch and error propagation, `responseStatus` without dumper, path parameter attribute).
- Extract `invokeErrorHandler` helper to dedupe the `c.Echo() != nil` guard used in two middleware code paths.
- When `io.ReadAll` of the request body fails during dump, record the error on the span and set body to `[read-error]` instead of silently continuing.
- Always replace the response body with `[excluded]` when `skipRespBody` is set, regardless of whether it was empty.

## Test plan

- `go test -race -cover ./...` passes locally.