### PR TITLE
docs: add agent guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .golangci.yml
-AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Repository Guidelines
+
+Single-package Echo OpenTelemetry middleware. Start with `middleware.go`, `helpers.go`, then the matching tests; there are no subpackages or generated files.
+
+## API and Imports
+
+- Module path is `github.com/adlandh/echo-otel-middleware/v2`; keep the `/v2` suffix in imports and docs.
+- Package name is `echootelmiddleware`; README examples alias the import to that name.
+- Uses Echo v5 (`github.com/labstack/echo/v5`), whose handlers and skippers take `*echo.Context`.
+- Treat exported API as non-breaking: `Middleware`, `MiddlewareWithConfig`, `OtelConfig`, `BodySkipper`, `DefaultOtelConfig`.
+
+## Commands
+
+- CI tests: `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`
+- Pre-push tests: `go test -cover -race ./...`
+- Focused test: `go test -run TestName .`
+- Lint: `golangci-lint run`
+
+## Tooling Gotchas
+
+- `go.mod` declares Go `1.25.0`; CI installs Go `1.25`.
+- `.lefthook.yml` and CI lint download `.golangci.yml` from `adlandh/golangci-lint-config` before running lint. Do not rely on local edits to `.golangci.yml`; upstream the shared config instead.
+- Current lint config sets `run.tests: false`, so `*_test.go` files are not linted.
+
+## Behavior Notes
+
+- `AreHeadersDump` defaults true; `IsBodyDump` defaults false. Body dumping can capture PII/secrets, so prefer `BodySkipper` for exclusions.
+- Request/response attribute names and value limits are byte-based and must preserve valid UTF-8; see `helpers_test.go` before changing truncation.

--- a/skills/golang-echo-otel-middleware/SKILL.md
+++ b/skills/golang-echo-otel-middleware/SKILL.md
@@ -1,0 +1,63 @@
+# Skill: golang-echo-otel-middleware
+
+Use this skill when adding or configuring `github.com/adlandh/echo-otel-middleware/v2` in a Go Echo application, or when writing examples for this middleware.
+
+## Essentials
+
+- Import path must include `/v2`: `github.com/adlandh/echo-otel-middleware/v2`.
+- Alias examples as `echootelmiddleware` to match the package name and README.
+- This middleware targets Echo v5: use `github.com/labstack/echo/v5` and handler signatures with `*echo.Context`.
+- `Middleware()` uses global OpenTelemetry tracer provider and propagator; use `MiddlewareWithConfig` when the app owns explicit OTel setup.
+
+## Basic Usage
+
+```go
+app := echo.New()
+app.Use(echootelmiddleware.Middleware())
+```
+
+Use explicit config when a tracer provider or propagator is constructed by the application:
+
+```go
+app.Use(echootelmiddleware.MiddlewareWithConfig(echootelmiddleware.OtelConfig{
+	TracerProvider: tp,
+	Propagator:     otel.GetTextMapPropagator(),
+}))
+```
+
+## Config Defaults
+
+- `TracerProvider`: `otel.GetTracerProvider()`.
+- `Propagator`: `otel.GetTextMapPropagator()`.
+- `Skipper`: Echo `middleware.DefaultSkipper`.
+- `BodySkipper`: no-op, returns `false, false`.
+- `AreHeadersDump`: `true`.
+- `IsBodyDump`: `false`.
+- `RemoveNewLines`: `false`.
+- `LimitNameSize` and `LimitValueSize`: `0`, meaning unlimited.
+
+## Safe Body Dumping
+
+- Body dumping is opt-in with `IsBodyDump: true` because it can capture PII, tokens, and secrets.
+- Prefer `BodySkipper` to exclude sensitive endpoints, compressed bodies, uploads, auth payloads, or large responses.
+- `BodySkipper` only runs when `IsBodyDump` is true and returns `(skipReqBody, skipRespBody)`.
+
+```go
+BodySkipper: func(c *echo.Context) (bool, bool) {
+	if c.Request().Header.Get("Content-Encoding") == "gzip" {
+		return true, true
+	}
+	return false, false
+},
+```
+
+## Attribute Limits
+
+- `LimitNameSize` and `LimitValueSize` are byte-based, not rune-based.
+- Truncation preserves valid UTF-8; values over a limit greater than 10 get a trailing `...`.
+- `RemoveNewLines` replaces `\n` with spaces in string attributes, useful for backends such as Sentry.
+
+## Do Not Assume
+
+- Metrics are not implemented in this middleware; do not add or document metrics unless explicitly requested.
+- Echo v4 examples are wrong for this package because context types and imports differ.


### PR DESCRIPTION
## Summary
- Add repository guidance for future agent sessions.
- Add a local skill for using the Echo OpenTelemetry middleware.
- Stop ignoring `AGENTS.md` so guidance can be tracked.