### PR TITLE
Fix response body buffering limits

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"strings"
@@ -207,8 +208,13 @@ func dumpRequestBody(request *http.Request, config OtelConfig, span oteltrace.Sp
 }
 
 // setupResponseDumper creates and sets up a response dumper.
-func setupResponseDumper(c *echo.Context, limitSize int) *response.Dumper {
-	respDumper := response.NewDumper(c.Response(), response.WithMaxBytes(limitSize))
+func setupResponseDumper(c *echo.Context, maxBodyDumpSize int64) *response.Dumper {
+	maxBytes := 0
+	if maxBodyDumpSize > 0 {
+		maxBytes = int(min(maxBodyDumpSize, math.MaxInt))
+	}
+
+	respDumper := response.NewDumper(c.Response(), response.WithMaxBytes(maxBytes))
 	c.SetResponse(respDumper)
 
 	return respDumper
@@ -235,7 +241,7 @@ func dumpReq(c *echo.Context, config OtelConfig, span oteltrace.Span, request *h
 		// Only install the response dumper if we plan to use it; otherwise the
 		// response is buffered for the full request lifetime for nothing.
 		if !skipRespBody {
-			respDumper = setupResponseDumper(c, config.LimitValueSize)
+			respDumper = setupResponseDumper(c, config.MaxBodyDumpSize)
 		}
 	}
 
@@ -271,8 +277,8 @@ func dumpResponseBody(c *echo.Context, respDumper *response.Dumper, config OtelC
 	respBody := bodyNonText
 	if isTextualContentType(c.Response().Header().Get(echo.HeaderContentType)) {
 		respBody = strings.ToValidUTF8(respDumper.GetResponse(), "")
-		if config.MaxBodyDumpSize > 0 && int64(len(respBody)) > config.MaxBodyDumpSize {
-			respBody = respBody[:config.MaxBodyDumpSize] + bodyTruncated
+		if respDumper.BytesWritten() > len(respDumper.Body()) {
+			respBody += bodyTruncated
 		}
 	}
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -927,6 +927,7 @@ func TestResponseBodyNonText(t *testing.T) {
 func TestResponseBodyTruncated(t *testing.T) {
 	sr := tracetest.NewSpanRecorder()
 	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	var buffered int
 
 	router := echo.New()
 	router.Use(MiddlewareWithConfig(OtelConfig{
@@ -935,12 +936,22 @@ func TestResponseBodyTruncated(t *testing.T) {
 		MaxBodyDumpSize: 4,
 	}))
 	router.GET("/x", func(c *echo.Context) error {
-		return c.String(http.StatusOK, "abcdefghij")
+		err := c.String(http.StatusOK, "abcdefghij")
+		require.NoError(t, err)
+
+		dumper, ok := c.Response().(interface{ Body() []byte })
+		require.True(t, ok)
+		buffered = len(dumper.Body())
+
+		return nil
 	})
 
 	r := httptest.NewRequest("GET", "/x", http.NoBody)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
+
+	assert.Equal(t, 4, buffered)
+	assert.Equal(t, "abcdefghij", w.Body.String())
 
 	attrs := sr.Ended()[0].Attributes()
 	assert.Contains(t, attrs, attribute.String("http.response.body", "abcd[truncated]"))


### PR DESCRIPTION
## Summary

- Apply `MaxBodyDumpSize` to response buffering instead of the generic attribute size limit.
- Preserve complete response delivery while recording a truncated body dump.
- Detect truncation using the response dumper’s buffered byte counts.
- Extend coverage to verify buffering and full response output.

## Testing

- Not run (not requested)